### PR TITLE
setpoint changes for better visualization

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -25,7 +25,7 @@ function backupAllTables()
 {
 	global $dbConfig;
 
-	$tableList = array( 'hvac_cycles', 'hvac_status', 'run_times', 'temperatures', 'thermostats', 'time_index' );
+	$tableList = array( 'hvac_cycles', 'hvac_status', 'run_times', 'setpoints', 'temperatures', 'thermostats', 'time_index' );
 	foreach(  $tableList as $tableName )
 	{
 		backupOneTable(  $dbConfig['table_prefix'] . $tableName );

--- a/install/upgrade_setpoints.php
+++ b/install/upgrade_setpoints.php
@@ -1,0 +1,97 @@
+<?php
+require_once '../common.php';
+
+/**
+  * This code upgrades "version 2" code for the setpoints addition.  
+  */
+
+$new_prefix = 'thermo2__';
+//$tstat_uuid = '5cdad4276ec5';
+
+
+/**
+  * Step 1 is ALWAYS ... "Make a backup before you do anything!"
+  *
+  * There are six total tables.
+  */
+
+$file = 'backup_hvac_cycles.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}hvac_cycles";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+$file = 'backup_hvac_status.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}hvac_status";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+$file = 'backup_run_times.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}run_times";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+$file = 'backup_temperatures.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}temperatures";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+$file = 'backup_thermostats.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}thermostats";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+// This table is included for completness only
+$file = 'backup_time_index.sql';
+$sql = "SELECT * INTO OUTFILE {$file} FROM {$new_prefix}time_index";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+/**
+  * The following code block is an example of how to restore from a backup - perhaps, it is untested
+  *
+  * $file = 'backup_hvac_cycles.sql';
+  * $sql = "LOAD DATA INFILE {$file} INTO TABLE {$old_prefix}hvac_cycles";
+  * $query = $pdo->prepare($sql);
+  * $query->execute(array($id));
+  *
+  * Both export and import are generic enough that a function could be written and
+  *  the table name could be passed in as a single parameter and the rest dynamically
+  *  generated.
+  */
+
+
+/**
+  * Create the new tables
+  *
+  */
+
+$sql = "ALTER TABLE {$new_prefix}thermostats
+  				MODIFY id TINYINT unsigned NOT NULL";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+
+$sql = "CREATE TABLE IF NOT EXISTS {$new_prefix}setpoints (
+  				id tinyint(3) unsigned NOT NULL,
+  				set_point decimal(5,2) DEFAULT NULL,
+  				switch_time datetime NOT NULL,
+  				KEY id (id)
+				) ENGINE=InnoDB DEFAULT CHARSET=utf8";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+
+$sql = "ALTER TABLE {$new_prefix}setpoints
+  				ADD CONSTRAINT {$new_prefix}setpoints_ibfk_1 
+  				FOREIGN KEY (id) 
+  				REFERENCES {$new_prefix}thermostats (id)";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+
+$sql = "ALTER TABLE {$new_prefix}temperatures
+					DROP set_point";
+$query = $pdo->prepare($sql);
+$query->execute(array($id));
+
+?>

--- a/resources/thermo.css
+++ b/resources/thermo.css
@@ -36,7 +36,7 @@ div.status
 }
 div.status p
 {
-	padding: 5px;
+	padding: 0px;
 	top: -24px;
 	vertical-align: middle;
 }
@@ -70,31 +70,31 @@ div.status img
 	*/
 div.status img.fan_on
 {
-	background-position: 192px 0px;
+	background-position: 194px 0px;
 }
 div.status img.fan_off
 {
-	background-position: 192px -48px;
+	background-position: 194px -48px;
 }
 div.status img.compressor_on
 {
-	background-position: 144px 0px;
+	background-position: 146px 0px;
 }
 div.status img.compressor_off
 {
-	background-position: 144px -48px;
+	background-position: 146px -48px;
 }
 div.status img.heater_on
 {
-	background-position: 96px 0px;
+	background-position: 98px 0px;
 }
 div.status img.heater_off
 {
-	background-position: 96px -48px;
+	background-position: 98px -48px;
 }
 div.status img.wheels
 {
-	background-position: 336px 0px;
+	background-position: 338px 0px;
 }
 
 /** Charts and tables

--- a/scripts/thermo_update_temps.php
+++ b/scripts/thermo_update_temps.php
@@ -11,7 +11,7 @@ $yesterday = date( 'Y-m-d', strtotime( 'yesterday' ));
 
 try
 {
-	$sql = "INSERT INTO {$dbConfig['table_prefix']}temperatures( tstat_uuid, date, indoor_temp, outdoor_temp, indoor_humidity, outdoor_humidity, set_point ) VALUES ( ?, CONCAT( SUBSTR( NOW() , 1, 15 ) , \"0:00\" ), ?, ?, ?, ?, ? )";
+	$sql = "INSERT INTO {$dbConfig['table_prefix']}temperatures( tstat_uuid, date, indoor_temp, outdoor_temp, indoor_humidity, outdoor_humidity ) VALUES ( ?, CONCAT( SUBSTR( NOW() , 1, 15 ) , \"0:00\" ), ?, ?, ?, ? )";
 	$queryTemp = $pdo->prepare($sql);
 
 	$sql = "DELETE FROM {$dbConfig['table_prefix']}run_times WHERE date = ? AND tstat_uuid = ?";
@@ -82,12 +82,9 @@ foreach( $thermostats as $thermostatRec )
 			}
 
 			// Log the indoor and outdoor temperatures for this half-hour increment
-// t_heat or t_cool may not exist if thermostat is running in battery mode
-			$target = ($stat->tmode == 1) ? $stat->t_heat : $stat->t_cool;
 
-			logIt( "temps: Target $target" );
-			logit( "temps: UUID $stat->uuid IT " . $stat->temp . " OT $outdoorTemp IH $stat->humidity OH $outdoorHumidity TARGT $target" );
-			$queryTemp->execute(array( $stat->uuid, $stat->temp, $outdoorTemp, $stat->humidity, $outdoorHumidity, $target ) );
+			logit( "temps: UUID $stat->uuid IT " . $stat->temp . " OT $outdoorTemp IH $stat->humidity OH $outdoorHumidity" );
+			$queryTemp->execute(array( $stat->uuid, $stat->temp, $outdoorTemp, $stat->humidity, $outdoorHumidity ) );
 
 			//$runTimeData = $stat->getDataLog();
 			$stat->getDataLog();


### PR DESCRIPTION
Created "upgrade_setpoints.php" to support this upgrade.  This file is
untested so proceed at your own risk (highly recommend db backup prior
to performing this upgrade).

Summary of changes:
1) Changed the 'thermostats' table 'id' column to a tinyint unsigned
type.
2) Added a new database table called setpoints with foreign key
reference to thermostats.id.
3) Dropped the 'temperatures'.'set_point' column as it's no longer
needed.
4) Modified the update status and temps scripts to manage the new
setpoints database table and remove the old method.
5) Modified the draw_daily.php to render as an overlay the new set_point
logic.  Also adjusted previous settings for pixel calculations of the
heat/cool/fan status's as I discovered they were slightly misaligned.
Added commentary with all changes.
6) Modified other support scripts where I found they could be updated
but I'm not sure all of them are still even being used.
